### PR TITLE
html archetype asset path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 target/
 .settings/
 bin/
+*.iml
+.idea

--- a/src/main/resources/archetype-resources/html/pom.xml
+++ b/src/main/resources/archetype-resources/html/pom.xml
@@ -15,6 +15,8 @@
 	<properties>
 		<gwt.module>${package}.${JavaGameClassName}</gwt.module>
 		<gwt.name>${rootArtifactId}</gwt.name>
+        <asset.input.dir>${project.basedir}/../desktop/assets</asset.input.dir>
+        <asset.output.dir>${project.build.directory}/${project.build.finalName}</asset.output.dir>
 	</properties>
 
 	<dependencies>
@@ -59,6 +61,16 @@
 	</dependencies>
 
 	<build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/src/main/java</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/*.gwt.xml</include>
+                </includes>
+            </resource>
+        </resources>
+
 		<plugins>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
@@ -72,7 +84,7 @@
 					</execution>
 				</executions>
 				<configuration>
-					<runTarget>index.html</runTarget>
+					<runTarget>${JavaGameClassName}.html</runTarget>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/resources/archetype-resources/html/src/main/java/__JavaGameClassName__.gwt.xml
+++ b/src/main/resources/archetype-resources/html/src/main/java/__JavaGameClassName__.gwt.xml
@@ -10,6 +10,6 @@
   <public path="resources" />
 
   <entry-point class='${package}.html.${JavaGameClassName}Html'/>
-  <set-configuration-property name="gdx.assetpath" value="../desktop/assets/,desktop/assets" />
-  <set-configuration-property name="gdx.assetoutputpath" value="src/main/webapp,html/target/${rootArtifactId}-html-${version})" />
+  <set-configuration-property name="gdx.assetpath" value="${asset.input.dir}" />
+  <set-configuration-property name="gdx.assetoutputpath" value="${asset.output.dir}" />
 </module>


### PR DESCRIPTION
updated the gwt module file to use maven's resource filtering to figure out the the paths to the resources so the root directory will not be based on what folder you open your project in the IDE

When testing this solution out I found that when the PreloaderBundleGenerator executes it appears it has a problem with the String replacement due to Window slashes.

Example:
gdx.assetoutputpath=C:\test\target

actual 'assets.txt':
d:C:/test/target/
i:C:/test/target//libgdx-logo.png

expected 'assets.txt':
d:C:/test/target
i:libgdx-logo.png

I tested out hardcoding the paths in my gwt module's xml file to have UNIX slashes and the assets.txt look correct and running "gwt:run" and viewing the page in the browser worked.

Sorry, I did not take the time to attempt to make the fix in libgdx-gwt.  If you have any questions or concerns let me know.
