### PR TITLE
Fixed archetype to reflect desktop native jar structure changes in 0.9.9

### DIFF
--- a/src/main/resources/archetype-resources/desktop/pom.xml
+++ b/src/main/resources/archetype-resources/desktop/pom.xml
@@ -39,7 +39,21 @@
 			<groupId>com.badlogic.gdx</groupId>
 			<artifactId>gdx-platform</artifactId>
 			<version>${gdx.version}</version>
-			<classifier>natives-desktop</classifier>
+			<classifier>natives-linux</classifier>
+		</dependency>
+		
+		<dependency>
+			<groupId>com.badlogic.gdx</groupId>
+			<artifactId>gdx-platform</artifactId>
+			<version>${gdx.version}</version>
+			<classifier>natives-mac</classifier>
+		</dependency>
+		
+		<dependency>
+			<groupId>com.badlogic.gdx</groupId>
+			<artifactId>gdx-platform</artifactId>
+			<version>${gdx.version}</version>
+			<classifier>natives-win</classifier>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Archetype was generating a pom.xml with errors due to native files being split into natives-linux, natives-mac and natives-win.
