### PR TITLE
Fixed libgdx version tag to 0.9.9 instead of 0.9.9-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.badlogic.gdx</groupId>
 	<artifactId>gdx-archetype</artifactId>
-	<version>0.9.9-SNAPSHOT</version>
+	<version>0.9.9</version>
 	<packaging>maven-archetype</packaging>
 
 	<name>Libgdx Project Archetype</name>


### PR DESCRIPTION
See: https://code.google.com/p/libgdx/issues/detail?id=1458
