### PR TITLE
Android: Set minimum sdk to 8 and target to 19

### DIFF
--- a/src/main/resources/archetype-resources/android/AndroidManifest.xml
+++ b/src/main/resources/archetype-resources/android/AndroidManifest.xml
@@ -7,7 +7,7 @@
 					android:screenOrientation="landscape"
 					android:versionCode="1"
 					android:versionName="1.0">
-	<uses-sdk android:minSdkVersion="6" android:targetSdkVersion="11" />
+	<uses-sdk android:minSdkVersion="8" android:targetSdkVersion="19" />
 	<application android:icon="@drawable/icon" android:label="@string/app_name" android:debuggable="true">
 		<activity android:name="${JavaGameClassName}Activity"
 							android:label="@string/app_name"


### PR DESCRIPTION
Dropped support before 2.2 (8) and we compile with 19
