### PR TITLE
Versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.badlogic.gdx</groupId>
 	<artifactId>gdx-archetype</artifactId>
-	<version>0.9.9</version>
+	<version>1.0.0</version>
 	<packaging>maven-archetype</packaging>
 
 	<name>Libgdx Project Archetype</name>

--- a/src/main/resources/archetype-resources/android/pom.xml
+++ b/src/main/resources/archetype-resources/android/pom.xml
@@ -30,20 +30,17 @@
 		<dependency>
 			<groupId>com.badlogicgames.gdx</groupId>
 			<artifactId>gdx-backend-android</artifactId>
-			<version>${gdx.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.badlogicgames.gdx</groupId>
 			<artifactId>gdx-platform</artifactId>
-			<version>${gdx.version}</version>
 			<classifier>natives-armeabi</classifier>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.badlogicgames.gdx</groupId>
 			<artifactId>gdx-platform</artifactId>
-			<version>${gdx.version}</version>
 			<classifier>natives-armeabi-v7a</classifier>
 			<scope>provided</scope>
 		</dependency>

--- a/src/main/resources/archetype-resources/android/src/main/java/android/__JavaGameClassName__Activity.java
+++ b/src/main/resources/archetype-resources/android/src/main/java/android/__JavaGameClassName__Activity.java
@@ -16,7 +16,6 @@ public class ${JavaGameClassName}Activity extends AndroidApplication {
 	public void onCreate(Bundle savedInstanceState) {
 			super.onCreate(savedInstanceState);
 			AndroidApplicationConfiguration config = new AndroidApplicationConfiguration();
-			config.useGL20 = true;
 			initialize(new ${JavaGameClassName}(), config);
 	}
 }

--- a/src/main/resources/archetype-resources/core/pom.xml
+++ b/src/main/resources/archetype-resources/core/pom.xml
@@ -16,7 +16,6 @@
 		<dependency>
 			<groupId>com.badlogicgames.gdx</groupId>
 			<artifactId>gdx</artifactId>
-			<version>${gdx.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/resources/archetype-resources/core/src/main/java/core/__JavaGameClassName__.java
+++ b/src/main/resources/archetype-resources/core/src/main/java/core/__JavaGameClassName__.java
@@ -3,7 +3,7 @@
 #set( $symbol_escape = '\' )
 package ${package}.core;
 
-import com.badlogic.gdx.graphics.GL10;
+import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.ApplicationListener;
@@ -28,7 +28,7 @@ public class ${JavaGameClassName} implements ApplicationListener {
 	public void render () {
 		elapsed += Gdx.graphics.getDeltaTime();
 		Gdx.gl.glClearColor(0, 0, 0, 0);
-		Gdx.gl.glClear(GL10.GL_COLOR_BUFFER_BIT);
+		Gdx.gl.glClear(GL30.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		batch.draw(texture, 100+100*(float)Math.cos(elapsed), 100+25*(float)Math.sin(elapsed));
 		batch.end();

--- a/src/main/resources/archetype-resources/desktop/pom.xml
+++ b/src/main/resources/archetype-resources/desktop/pom.xml
@@ -26,19 +26,16 @@
 		<dependency>
 			<groupId>com.badlogicgames.gdx</groupId>
 			<artifactId>gdx</artifactId>
-			<version>${gdx.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.badlogicgames.gdx</groupId>
 			<artifactId>gdx-backend-lwjgl</artifactId>
-			<version>${gdx.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.badlogicgames.gdx</groupId>
 			<artifactId>gdx-platform</artifactId>
-			<version>${gdx.version}</version>
 			<classifier>natives-desktop</classifier>
 		</dependency>
 	</dependencies>

--- a/src/main/resources/archetype-resources/desktop/src/main/java/java/__JavaGameClassName__Desktop.java
+++ b/src/main/resources/archetype-resources/desktop/src/main/java/java/__JavaGameClassName__Desktop.java
@@ -11,7 +11,6 @@ import ${package}.core.${JavaGameClassName};
 public class ${JavaGameClassName}Desktop {
 	public static void main (String[] args) {
 		LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
-		config.useGL20 = true;
 		new LwjglApplication(new ${JavaGameClassName}(), config);
 	}
 }

--- a/src/main/resources/archetype-resources/html/pom.xml
+++ b/src/main/resources/archetype-resources/html/pom.xml
@@ -27,7 +27,6 @@
 		<dependency>
 			<groupId>com.badlogicgames.gdx</groupId>
 			<artifactId>gdx-backend-gwt</artifactId>
-			<version>${gdx.version}</version>
 		</dependency>
 
 		<dependency>
@@ -41,7 +40,6 @@
 		<dependency>
 			<groupId>com.badlogicgames.gdx</groupId>
 			<artifactId>gdx</artifactId>
-			<version>${gdx.version}</version>
 			<classifier>sources</classifier>
 			<scope>provided</scope>
 		</dependency>
@@ -49,7 +47,6 @@
 		<dependency>
 			<groupId>com.badlogicgames.gdx</groupId>
 			<artifactId>gdx-backend-gwt</artifactId>
-			<version>${gdx.version}</version>
 			<classifier>sources</classifier>
 			<scope>provided</scope>
 		</dependency>

--- a/src/main/resources/archetype-resources/ios/pom.xml
+++ b/src/main/resources/archetype-resources/ios/pom.xml
@@ -23,7 +23,6 @@
 		<dependency>
 			<groupId>com.badlogic.gdx</groupId>
 			<artifactId>gdx-backend-ios</artifactId>
-			<version>${gdx.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/resources/archetype-resources/ios/pom.xml
+++ b/src/main/resources/archetype-resources/ios/pom.xml
@@ -20,6 +20,7 @@
 			<version>${project.version}</version>
 		</dependency>
 
+		<!-- requires robovm upgrades -->
 		<dependency>
 			<groupId>com.badlogic.gdx</groupId>
 			<artifactId>gdx-backend-ios</artifactId>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -16,7 +16,14 @@
 	</properties>
 	<dependencyManagement>
 		<dependencies>
+			<!-- core dependencies -->
+			<dependency>
+				<groupId>com.badlogicgames.gdx</groupId>
+				<artifactId>gdx</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 
+			<!-- android-specific dependencies -->
 			<dependency>
 				<groupId>com.badlogicgames.gdx</groupId>
 				<artifactId>gdx-backend-android</artifactId>
@@ -27,6 +34,48 @@
 				<groupId>com.badlogicgames.gdx</groupId>
 				<artifactId>gdx-platform</artifactId>
 				<version>${project.version}</version>
+				<classifier>natives-armeabi</classifier>
+				<scope>provided</scope>
+			</dependency>
+
+
+			<!-- desktop-specific dependencies -->
+			<dependency>
+				<groupId>com.badlogicgames.gdx</groupId>
+				<artifactId>gdx-backend-lwjgl</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.badlogicgames.gdx</groupId>
+				<artifactId>gdx-platform</artifactId>
+				<version>${project.version}</version>
+				<classifier>natives-desktop</classifier>
+			</dependency>
+
+			<dependency>
+				<groupId>com.badlogicgames.gdx</groupId>
+				<artifactId>gdx-platform</artifactId>
+				<version>${project.version}</version>
+				<classifier>natives-armeabi-v7a</classifier>
+				<scope>provided</scope>
+			</dependency>
+
+			<!-- gwt-specific dependencies -->
+			<dependency>
+				<groupId>com.badlogicgames.gdx</groupId>
+				<artifactId>gdx</artifactId>
+				<version>${project.version}</version>
+				<classifier>sources</classifier>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>com.badlogicgames.gdx</groupId>
+				<artifactId>gdx-backend-gwt</artifactId>
+				<version>${project.version}</version>
+				<classifier>sources</classifier>
+				<scope>provided</scope>
 			</dependency>
 
 			<dependency>
@@ -35,24 +84,13 @@
 				<version>${project.version}</version>
 			</dependency>
 
-			<dependency>
-				<groupId>com.badlogicgames.gdx</groupId>
-				<artifactId>gdx</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>com.badlogicgames.gdx</groupId>
-				<artifactId>gdx-backend-lwjgl</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-
+			<!-- ios-specific dependencies -->
+			<!-- requires robovm upgrades -->
 			<dependency>
 				<groupId>com.badlogic.gdx</groupId>
 				<artifactId>gdx-backend-ios</artifactId>
 				<version>${project.version}</version>
 			</dependency>
-
 		</dependencies>
 	</dependencyManagement>
 
@@ -61,6 +99,10 @@
 		<repository>
 			<id>gdx-nightlies</id>
 			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+		</repository>
+		<repository>
+			<id>gdx-releases</id>
+			<url>https://oss.sonatype.org/content/repositories/releases/</url>
 		</repository>
 	</repositories>
 

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-				 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>\${groupId}</groupId>
 	<artifactId>\${artifactId}</artifactId>
@@ -9,12 +9,53 @@
 	<name>\${JavaGameClassName} Parent</name>
 
 	<properties>
-		<gdx.version>${project.version}</gdx.version>
 		<android.version>4.1.1.4</android.version>
 		<android.maven.version>3.8.1</android.maven.version>
 		<gwt.version>2.5.0</gwt.version>
 		<gwt.maven.version>2.5.0</gwt.maven.version>
 	</properties>
+	<dependencyManagement>
+		<dependencies>
+
+			<dependency>
+				<groupId>com.badlogicgames.gdx</groupId>
+				<artifactId>gdx-backend-android</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.badlogicgames.gdx</groupId>
+				<artifactId>gdx-platform</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.badlogicgames.gdx</groupId>
+				<artifactId>gdx-backend-gwt</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.badlogicgames.gdx</groupId>
+				<artifactId>gdx</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.badlogicgames.gdx</groupId>
+				<artifactId>gdx-backend-lwjgl</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.badlogic.gdx</groupId>
+				<artifactId>gdx-backend-ios</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+		</dependencies>
+	</dependencyManagement>
+
 
 	<repositories>
 		<repository>


### PR DESCRIPTION
saw @troger's thread a little too late

this PR upgrades to v1.0.0 and allows you to upgrade versions via mvn:versions plugin

Works for desktop, android, and html. RoboVM would require additional changes that could have been found in @troger's PR.
