### PR TITLE
Update archetype version in README.md as 0.9.9 will not be found

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Creating a project using the archetype is accomplished like so:
     -DarchetypeRepository=$HOME/.m2/repository \
     -DarchetypeGroupId=com.badlogic.gdx \
     -DarchetypeArtifactId=gdx-archetype \
-    -DarchetypeVersion=0.9.9
+    -DarchetypeVersion=1.0.0
 ```
 
 This will then ask you a few questions:


### PR DESCRIPTION
Maven gives the following error when trying to use archetype 0.9.9 but only have 1.0.0 installed.

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-archetype-plugin:2.2:generate (default-cli) on project standalone-pom: The desired archetype does not exist (com.badlogic.gdx:gdx-archetype:0.9.9) -> [Help 1]
