### PR TITLE
Updated android-maven-plugin ver to the 3.9.0-rc.3

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -10,7 +10,7 @@
 
 	<properties>
 		<android.version>4.1.1.4</android.version>
-		<android.maven.version>3.8.1</android.maven.version>
+		<android.maven.version>3.9.0-rc.3</android.maven.version>
 		<gwt.version>2.6.0</gwt.version>
 		<gwt.maven.version>2.6.0</gwt.maven.version>
 	</properties>


### PR DESCRIPTION
The reason is that using version 3.8.1 of
android-maven-plugin, if you compile with a maven
version 3.2.5+, the compilation of android module
fails for a:
  java.lang.NoClassDefFoundError:
  org/eclipse/aether/spi/connector/Transfer$State
