### PR TITLE
Update gdx to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Creating a project using the archetype is accomplished like so:
     -DarchetypeRepository=$HOME/.m2/repository \
     -DarchetypeGroupId=com.badlogic.gdx \
     -DarchetypeArtifactId=gdx-archetype \
-    -DarchetypeVersion=1.2.0
+    -DarchetypeVersion=1.9.10
 ```
 
 This will then ask you a few questions:

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.badlogic.gdx</groupId>
 	<artifactId>gdx-archetype</artifactId>
-	<version>1.2.0</version>
+	<version>1.9.10</version>
 	<packaging>maven-archetype</packaging>
 
 	<name>Libgdx Project Archetype</name>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -12,7 +12,8 @@
 		<android.version>4.1.1.4</android.version>
 		<android.maven.version>3.8.1</android.maven.version>
 		<gwt.version>2.6.0</gwt.version>
-		<gwt.maven.version>2.6.0</gwt.maven.version>
+    <gwt.maven.version>2.6.0</gwt.maven.version>
+    <gdx.version>${project.version}</gdx.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -20,20 +21,20 @@
 			<dependency>
 				<groupId>com.badlogicgames.gdx</groupId>
 				<artifactId>gdx</artifactId>
-				<version>${project.version}</version>
+				<version>\${gdx.version}</version>
 			</dependency>
 
 			<!-- android-specific dependencies -->
 			<dependency>
 				<groupId>com.badlogicgames.gdx</groupId>
 				<artifactId>gdx-backend-android</artifactId>
-				<version>${project.version}</version>
+				<version>\${gdx.version}</version>
 			</dependency>
 
 			<dependency>
 				<groupId>com.badlogicgames.gdx</groupId>
 				<artifactId>gdx-platform</artifactId>
-				<version>${project.version}</version>
+				<version>\${gdx.version}</version>
 				<classifier>natives-armeabi</classifier>
 				<scope>provided</scope>
 			</dependency>
@@ -43,20 +44,20 @@
 			<dependency>
 				<groupId>com.badlogicgames.gdx</groupId>
 				<artifactId>gdx-backend-lwjgl</artifactId>
-				<version>${project.version}</version>
+				<version>\${gdx.version}</version>
 			</dependency>
 
 			<dependency>
 				<groupId>com.badlogicgames.gdx</groupId>
 				<artifactId>gdx-platform</artifactId>
-				<version>${project.version}</version>
+				<version>\${gdx.version}</version>
 				<classifier>natives-desktop</classifier>
 			</dependency>
 
 			<dependency>
 				<groupId>com.badlogicgames.gdx</groupId>
 				<artifactId>gdx-platform</artifactId>
-				<version>${project.version}</version>
+				<version>\${gdx.version}</version>
 				<classifier>natives-armeabi-v7a</classifier>
 				<scope>provided</scope>
 			</dependency>
@@ -65,7 +66,7 @@
 			<dependency>
 				<groupId>com.badlogicgames.gdx</groupId>
 				<artifactId>gdx</artifactId>
-				<version>${project.version}</version>
+				<version>\${gdx.version}</version>
 				<classifier>sources</classifier>
 				<scope>provided</scope>
 			</dependency>
@@ -73,7 +74,7 @@
 			<dependency>
 				<groupId>com.badlogicgames.gdx</groupId>
 				<artifactId>gdx-backend-gwt</artifactId>
-				<version>${project.version}</version>
+				<version>\${gdx.version}</version>
 				<classifier>sources</classifier>
 				<scope>provided</scope>
 			</dependency>
@@ -81,7 +82,7 @@
 			<dependency>
 				<groupId>com.badlogicgames.gdx</groupId>
 				<artifactId>gdx-backend-gwt</artifactId>
-				<version>${project.version}</version>
+				<version>\${gdx.version}</version>
 			</dependency>
 
 			<!-- ios-specific dependencies -->
@@ -89,7 +90,7 @@
 			<dependency>
 				<groupId>com.badlogic.gdx</groupId>
 				<artifactId>gdx-backend-ios</artifactId>
-				<version>${project.version}</version>
+				<version>\${gdx.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Updated mvn archetype to use latest version of libgdx.
Extracted gdx.version property in pom file to make upgrading easier.
